### PR TITLE
Add the possibility to specify a custom knexfile.js location and re-create the knex instance for each connection attempt

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@ Does what it says on the tin. Reads your knexfile.js, tries to run
     SELECT 1 + 1;
 
 on your database, if it fails it waits 1000ms, tries again, and returns
-when it can run it. You can optionally pass a custom delay as last argv.
+when it can run it. You can optionally pass a custom delay as last argv or via
+the `--delay [delay]` argument. If your `knexfile.js` is not located in the
+current working directory you can use the
+`--knexfile [path/to/your/knexfile.js]` argument.
 
 ## What?
 

--- a/index.js
+++ b/index.js
@@ -9,21 +9,21 @@ if (isNaN(delay)) {
 }
 
 const knexfile = argv.knexfile || 'knexfile'
-const knex = require('knex')(
-  require(
-    require('path').join(process.cwd(), knexfile)
-  )
-)
 
 function wait () {
+  const knex = require('knex')(
+    require(
+      require('path').join(process.cwd(), knexfile)
+    )
+  )
   knex
     .raw('SELECT 1 + 1')
     .then(() => void process.exit())
-    .catch(err => {
+    .catch(err => knex.destroy().then(() => {
       console.error(err)
       console.error(`Connection failed, waiting ${delay}...`)
       setTimeout(wait, delay)
-    })
+    }))
 }
 
 wait()

--- a/index.js
+++ b/index.js
@@ -1,14 +1,17 @@
 #! /usr/bin/env node
 'use strict'
 
-let delay = parseInt(process.argv.pop(), 10)
+const argv = require('minimist')(process.argv.slice(2))
+
+let delay = parseInt(argv.delay || argv._.pop(), 10)
 if (isNaN(delay)) {
   delay = 1000
 }
 
+const knexfile = argv.knexfile || 'knexfile'
 const knex = require('knex')(
   require(
-    require('path').join(process.cwd(), 'knexfile')
+    require('path').join(process.cwd(), knexfile)
   )
 )
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "standard": "^5.4.1"
   },
   "dependencies": {
-    "knex": "^0.9.0"
+    "knex": "^0.9.0",
+    "minimist": "^1.2.0"
   },
   "bin": {
     "knex-waitfordb": "index.js"


### PR DESCRIPTION
Hi,

without destroying and re-creating the knex instance for each connection attempt the tool doesn't work (at least in my case) for my postgres database...

46fedd0 fixes that.

Cheers,
Patrick
